### PR TITLE
Small patches to fix the build on macOS

### DIFF
--- a/Source/GS/GSPresets.cpp
+++ b/Source/GS/GSPresets.cpp
@@ -67,7 +67,10 @@ void GSPresets::parseXmlInfo()
                         auto type = instrElem->hasAttribute("type") ? parseType(instrElem->getStringAttribute("type")) : EDSPType::PCM;
                         auto visible = instrElem->hasAttribute("visible") ? (instrElem->getIntAttribute("visible") == 1) : true;
 
-                        gameContainer.push_back(ProgramInfo{bankid, programid, name.getCharPointer(), device.getCharPointer(), type, visible});
+                        gameContainer.push_back(ProgramInfo{
+                            bankid, programid,
+                            std::string(name.getCharPointer()),
+                            std::string(device.getCharPointer()), type, visible});
                     }
                 }
             }

--- a/Source/GUI/ControlsTab.h
+++ b/Source/GUI/ControlsTab.h
@@ -3,13 +3,13 @@
 #include <JuceHeader.h>
 #include "PropertyListener.h"
 #include "SliderEx.h"
+#include "PresetCombo.h"
 
 namespace GSVST {
 
 class Processor;
 class MainWindow;
 
-class PresetCombo;
 class SliderEx;
 
 class ControlsTab : public juce::Component

--- a/Source/GUI/OverviewTab.h
+++ b/Source/GUI/OverviewTab.h
@@ -2,12 +2,12 @@
 
 #include <JuceHeader.h>
 #include "Processor/Types.h"
+#include "LevelMeter.h"
 
 namespace GSVST {
 
 class Processor;
 class PresetCombo;
-class LevelMeter;
 struct ProgramInfo;
 
 struct ChannelDesc

--- a/Source/GUI/PresetCombo.h
+++ b/Source/GUI/PresetCombo.h
@@ -1,11 +1,11 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "Presets/PresetsHandler.h"
 
 namespace GSVST {
 
 struct PresetsHandler;
-struct ProgramInfo;
 
 class ComboItem : public juce::PopupMenu::CustomComponent
 {


### PR DESCRIPTION
Only a few fixes were required, hopefully they're clear from the commit messages. I also converted the `.jucer` to a cmake build system using https://github.com/McMartin/FRUT because I don't have the patience to use xcode or Projucer.

With those small patches, everything seem to work as intended, I've tried loading the sf2 per your README's instructions and there's sound when I also put in the `.mid` files also extracted with the same program. I haven't done the midi channel -> program mapping just yet, nor mapped the "game songs" to the `.mid` files (if you have pointers on that, I'll be happy to read up), but the right notes come out with somewhat familiar instruments, just not the right ones.

fwiw I was also using REAPER in my short testing.